### PR TITLE
chore: remove top-level playbook and update ansible-lint to v26.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,8 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/ansible/ansible-lint
-    rev: v24.12.2
+    rev: v26.4.0
     hooks:
       - id: ansible-lint
         additional_dependencies:
-          - ansible-core>=2.15,<2.18
+          - ansible-core>=2.20

--- a/configure_online_laptop.yml
+++ b/configure_online_laptop.yml
@@ -1,8 +1,0 @@
----
-- name: Begin Bootstrap Role
-  hosts: all
-  gather_facts: true
-  tasks:
-    - name: Import bootstrap role
-      ansible.builtin.import_role:
-        name: bootstrap-online-machine


### PR DESCRIPTION
## Summary

- Removes `configure_online_laptop.yml` top-level playbook (superseded by role structure)
- Updates `ansible-lint` pre-commit hook from `v24.12.2` to `v26.4.0` and relaxes `ansible-core` constraint to `>=2.20` to fix Python 3.14 compatibility